### PR TITLE
Feature/config/listen

### DIFF
--- a/includes/Parser.hpp
+++ b/includes/Parser.hpp
@@ -41,7 +41,7 @@ class Parser {
 		std::string 	root;
 		Error*			error;
 
-		bool	is_port_only(std::string str) const;
+		bool		is_port_only(std::string str) const;
 };
 
 #endif /* PARSER_HPP */

--- a/includes/Parser.hpp
+++ b/includes/Parser.hpp
@@ -36,9 +36,11 @@ class Parser {
 
 		/* Private Attributes */
 		unsigned int	port;
+		std::string		address;
 		std::string 	root;
 		Error*			error;
 
+		bool	is_port_only(std::string str) const;
 };
 
 #endif /* PARSER_HPP */

--- a/includes/Parser.hpp
+++ b/includes/Parser.hpp
@@ -24,7 +24,8 @@ class Parser {
 		~Parser(void);
 
 		/* Getters and Setters */
-		unsigned int	get_listen(void) const;
+		unsigned int	get_port(void) const;
+		std::string		get_address(void) const;
 		std::string		get_root(void) const;
 		Error*			get_error(void) const;
 

--- a/includes/Parser.hpp
+++ b/includes/Parser.hpp
@@ -35,7 +35,7 @@ class Parser {
 	private:
 
 		/* Private Attributes */
-		unsigned int	listen;
+		unsigned int	port;
 		std::string 	root;
 		Error*			error;
 

--- a/includes/Parser.hpp
+++ b/includes/Parser.hpp
@@ -41,7 +41,7 @@ class Parser {
 		std::string 	root;
 		Error*			error;
 
-		bool		is_port_only(std::string str) const;
+		bool		is_port(std::string str) const;
 };
 
 #endif /* PARSER_HPP */

--- a/srcs/Parser.cpp
+++ b/srcs/Parser.cpp
@@ -19,7 +19,9 @@ unsigned int	Parser::get_listen(void) const { return (this->port); }
 
 Error*	Parser::get_error(void) const { return (this->error); }
 
-std::string	Parser::get_root(void) const { return (this->root); }
+std::string		Parser::get_address(void) const { return (this->address); }
+
+std::string		Parser::get_root(void) const { return (this->root); }
 
 /* ************************************************************************** */
 /* Other Functions                                                            */
@@ -30,7 +32,8 @@ std::string	Parser::get_root(void) const { return (this->root); }
 // false and this->error stops being nullptr to an instance of the Error class.
 bool	Parser::listen_handler(std::vector<std::string> command) {
 
-	int		port;
+	int					port;
+	std::string			address;
 	std::stringstream	s;
 
 	if (command.empty() || command[0] != "listen") {
@@ -65,5 +68,14 @@ bool	Parser::root_handler(std::vector<std::string> command) {
 		return (false);
 	}
 	this->root = command[1];
+	return (true);
+}
+
+
+bool	Parser::is_port_only(std::string str) const{
+	for ( size_t i = 0; i < str.size(); i++) {
+		if (isdigit(str[i]))
+			return (false);
+	}
 	return (true);
 }

--- a/srcs/Parser.cpp
+++ b/srcs/Parser.cpp
@@ -15,9 +15,9 @@ Parser::~Parser( void ) {
 /* Getters and Setters                                                        */
 /* ************************************************************************** */
 
-unsigned int	Parser::get_listen(void) const { return (this->port); }
+Error*			Parser::get_error(void) const { return (this->error); }
 
-Error*	Parser::get_error(void) const { return (this->error); }
+unsigned int	Parser::get_port(void) const { return (this->port); }
 
 std::string		Parser::get_address(void) const { return (this->address); }
 
@@ -32,7 +32,10 @@ std::string		Parser::get_root(void) const { return (this->root); }
 // false and this->error stops being nullptr to an instance of the Error class.
 bool	Parser::listen_handler(std::vector<std::string> command) {
 
-	int					port;
+// command.push_back("wrong");
+
+	// EXPECT_FALSE(this->parser->listen_handler(command));
+	// EXPECT_NE(this->parser->get_error(), nullptr);	int					port;
 	std::string			address;
 	std::stringstream	s;
 
@@ -52,7 +55,6 @@ bool	Parser::listen_handler(std::vector<std::string> command) {
 		this->error = new Error();
 		return (false);
 	}
-
 	this->port = port;
 	return (true);
 }

--- a/srcs/Parser.cpp
+++ b/srcs/Parser.cpp
@@ -4,7 +4,7 @@
 /* Constructors and Destructors                                               */
 /* ************************************************************************** */
 
-Parser::Parser( void ) : listen(80), error(nullptr) {}
+Parser::Parser( void ) : port(80), error(nullptr) {}
 
 Parser::~Parser( void ) {
 	if (this->error)
@@ -15,7 +15,7 @@ Parser::~Parser( void ) {
 /* Getters and Setters                                                        */
 /* ************************************************************************** */
 
-unsigned int	Parser::get_listen(void) const { return (this->listen); }
+unsigned int	Parser::get_listen(void) const { return (this->port); }
 
 Error*	Parser::get_error(void) const { return (this->error); }
 
@@ -50,7 +50,7 @@ bool	Parser::listen_handler(std::vector<std::string> command) {
 		return (false);
 	}
 
-	this->listen = port;
+	this->port = port;
 	return (true);
 }
 

--- a/srcs/Parser.cpp
+++ b/srcs/Parser.cpp
@@ -57,7 +57,7 @@ bool	Parser::listen_handler(std::vector<std::string> command) {
 			this->error = new Error();
 			return (false);
 		}
-		if (this->is_port_only(split_content[1]) == false) {
+		if (this->is_port(split_content[1]) == false) {
 			this->error = new Error();
 			return (false);
 		}
@@ -72,7 +72,7 @@ bool	Parser::listen_handler(std::vector<std::string> command) {
 		return (true);
 	}
 	// If no ":" are found, it means only an address or a port is delivered. Here we check if it is a port
-	else if (this->is_port_only(command[1]) == true) {
+	else if (this->is_port(command[1]) == true) {
 		s << command[1];
 		s >> n;
 		if (n <= 0 || n > 65535) {
@@ -104,7 +104,7 @@ bool	Parser::root_handler(std::vector<std::string> command) {
 }
 
 
-bool	Parser::is_port_only(std::string str) const{
+bool	Parser::is_port(std::string str) const{
 	for ( size_t i = 0; i < str.size(); i++) {
 		if (!isdigit(str[i]))
 			return (false);

--- a/srcs/Parser.cpp
+++ b/srcs/Parser.cpp
@@ -32,15 +32,12 @@ std::string		Parser::get_root(void) const { return (this->root); }
 // false and this->error stops being nullptr to an instance of the Error class.
 bool	Parser::listen_handler(std::vector<std::string> command) {
 
-// command.push_back("wrong");
-
-	// EXPECT_FALSE(this->parser->listen_handler(command));
-	// EXPECT_NE(this->parser->get_error(), nullptr);	int					port;
 	std::string					address;
 	std::stringstream			s;
 	int							n;
 	std::vector<std::string>	split_content;
 	size_t						pos;
+	
 	// Basic error handling
 	if (command.empty() || command[0] != "listen") {
 		this->error = new Error();
@@ -67,7 +64,7 @@ bool	Parser::listen_handler(std::vector<std::string> command) {
 		this->address = split_content[0];
 		s << split_content[1];
 		s >> n;
-		if (n <= 0) {
+		if (n <= 0 || n > 65535) {
 			this->error = new Error();
 			return (false);
 		}
@@ -78,7 +75,7 @@ bool	Parser::listen_handler(std::vector<std::string> command) {
 	else if (this->is_port_only(command[1]) == true) {
 		s << command[1];
 		s >> n;
-		if (n <= 0) {
+		if (n <= 0 || n > 65535) {
 			this->error = new Error();
 			return (false);
 		}
@@ -98,7 +95,6 @@ bool	Parser::listen_handler(std::vector<std::string> command) {
 // false and this->error stops being nullptr to an instance of the Error class.
 bool	Parser::root_handler(std::vector<std::string> command) {
 
-	std::string root;
 	if (command.size() != 2 || command[0] != "root") {
 		this->error = new Error();
 		return (false);

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -52,17 +52,34 @@ TEST_F(test_parser, test_listen_directive) {
 	EXPECT_FALSE(this->parser->listen_handler(command));
 	EXPECT_NE(this->parser->get_error(), nullptr);
 
-	// Testing successfull case
+	// Testing successfull case with port only
 	this->Reset();
 	command[1] = "443";
 
 	EXPECT_TRUE(this->parser->listen_handler(command));
 	EXPECT_EQ(this->parser->get_error(), nullptr);
-	EXPECT_EQ(this->parser->get_listen(), 443);
+	EXPECT_EQ(this->parser->get_port(), 443);
+
+	// Testing successful case with address only
+	this->Reset();
+	command[1] = "html";
+
+	EXPECT_TRUE(this->parser->listen_handler(command));
+	EXPECT_EQ(this->parser->get_error(), nullptr);
+	EXPECT_EQ(this->parser->get_address(), "html");
+
+	// Testing successful case with address and port
+	this->Reset();
+	command[1] = "html:120";
+
+	EXPECT_TRUE(this->parser->listen_handler(command));
+	EXPECT_EQ(this->parser->get_error(), nullptr);
+	EXPECT_EQ(this->parser->get_address(), "html");
+	EXPECT_EQ(this->parser->get_port(), 120);
 
 	// Testing default value
 	this->Reset();
-	EXPECT_EQ(this->parser->get_listen(), 80);
+	EXPECT_EQ(this->parser->get_port(), 80);
 }
 
 

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -42,10 +42,10 @@ TEST_F(test_parser, test_listen_directive) {
 	EXPECT_NE(this->parser->get_error(), nullptr);
 
 	// Testing with wrong arguments command
-	command[1] = "-1";
+	command.push_back("-1");
 
-	EXPECT_FALSE(this->parser->listen_handler(command));
-	EXPECT_NE(this->parser->get_error(), nullptr);
+	EXPECT_TRUE(this->parser->listen_handler(command));
+	EXPECT_EQ(this->parser->get_address(), "-1");
 
 	// Testing successfull case with port only
 	this->Reset();

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -42,11 +42,6 @@ TEST_F(test_parser, test_listen_directive) {
 	EXPECT_NE(this->parser->get_error(), nullptr);
 
 	// Testing with wrong arguments command
-	command.push_back("wrong");
-
-	EXPECT_FALSE(this->parser->listen_handler(command));
-	EXPECT_NE(this->parser->get_error(), nullptr);
-
 	command[1] = "-1";
 
 	EXPECT_FALSE(this->parser->listen_handler(command));


### PR DESCRIPTION
Made a parser for the listen directive. It handles the following:

- listen: address:port
- listen: address
- listen: port

This is already merged with the current main, meaning it already has tests for the default config. Although the program compiles and runs, it won't pass all tests if the person running the program does not have the default config file in their pc.