### PR TITLE
SMT now has make_shared to ease use of smart pointer

### DIFF
--- a/includes/smt.hpp
+++ b/includes/smt.hpp
@@ -22,6 +22,8 @@ class unique_ptr {
 
         T& operator*() { return *(this->pointer); }
 
+        operator bool() { return (this->pointer != NULL); }
+
     private:
 
         T* pointer;
@@ -31,9 +33,9 @@ template<typename T>
 class shared_ptr {
     public:
 
-        shared_ptr() : pointer(NULL), referenceCount(new uint(0)) {}
+        shared_ptr() : pointer(NULL), referenceCount(new unsigned int(0)) {}
 
-        shared_ptr(T* ptr) : pointer(ptr), referenceCount(new uint(1)) {}
+        shared_ptr(T* ptr) : pointer(ptr), referenceCount(new unsigned int(1)) {}
 
         shared_ptr(const shared_ptr& other) {
             this->pointer = other.pointer;
@@ -55,6 +57,8 @@ class shared_ptr {
 
         T& operator*() { return *(this->pointer); }
 
+        operator bool() const { return (this->pointer != NULL); }
+
     private:
 
         void destroy() {
@@ -66,8 +70,13 @@ class shared_ptr {
         }
 
         T*    pointer;
-        uint* referenceCount;
+        unsigned int* referenceCount;
 };
+
+template <typename T, typename... Args>
+shared_ptr<T> make_shared(Args... args) {
+    return shared_ptr<T>(new T(args...));
+}
 
 } // namespace smt
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ if (test)
     add_test(webserv_gtest webserv_test)
 
     target_link_libraries(webserv_test
+		PRIVATE pthread
         PRIVATE 42::webserv_lib
         PRIVATE gtest
         PRIVATE gmock

--- a/tests/test_smt.cpp
+++ b/tests/test_smt.cpp
@@ -1,4 +1,5 @@
 #include "SocketConnection.hpp"
+#include "TCPSocket.hpp"
 #include "smt.hpp"
 
 #include <gtest/gtest.h>
@@ -67,4 +68,12 @@ TEST(SmartPointerTests, TestVectorSharedPtrSockets) {
     vec.push_back(SocketAddressSharedPtr);
     vec.push_back(SocketAddressOtherSharedPtr);
     ASSERT_EQ(vec.at(0)->address(), vec.at(1)->address());
+}
+
+TEST(SmartPointerTests, TestVariadicArgumentsMakeShared) {
+    smt::shared_ptr<webserv::SocketAddress> socketAddress = smt::make_shared<webserv::SocketAddress>();
+    ASSERT_TRUE(socketAddress);
+
+    smt::shared_ptr<webserv::TCPSocket> tcp = smt::make_shared<webserv::TCPSocket>(8080);
+    ASSERT_TRUE(tcp);
 }


### PR DESCRIPTION
Also allows for null checking
`
shared_ptr<int> myIntPointer = make_shared<int>();
if (myIntPointer)
 // Do something
`